### PR TITLE
JRTB-3: added Command pattern for handling Telegram Bot commands

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,30 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="bb2f03f7-ca9c-49d7-bf48-9117d7414d4f" name="Changes" comment="JRTB-2 added stub telegram bot to the project" />
+    <list default="true" id="bb2f03f7-ca9c-49d7-bf48-9117d7414d4f" name="Changes" comment="JRTB-2: updated project version and added to RELEASE_NOTES">
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/Command.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/CommandContainer.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/CommandName.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/HelpCommand.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/NoCommand.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/StartCommand.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/StopCommand.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/command/UnknownCommand.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/service/SendBotMessageService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/service/SendBotMessageServiceImpl.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/SendBotMessageServiceTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/AbstractCommandTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/CommandContainerTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/HelpCommandTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/NoCommandTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/StartCommandTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/StopCommandTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/github/fearthe13372/jrtb/command/UnknownCommandTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pom.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/bot/JavaRushTelegramBot.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/fearthe13372/jrtb/bot/JavaRushTelegramBot.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/target/classes/application.properties" beforeDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -13,6 +36,8 @@
   <component name="FileTemplateManagerImpl">
     <option name="RECENT_TEMPLATES">
       <list>
+        <option value="Interface" />
+        <option value="Enum" />
         <option value="Class" />
       </list>
     </option>
@@ -51,25 +76,26 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RequestMappingsPanelOrder0": "0",
-    "RequestMappingsPanelOrder1": "1",
-    "RequestMappingsPanelWidth0": "75",
-    "RequestMappingsPanelWidth1": "75",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "nodejs_package_manager_path": "npm",
-    "project.structure.last.edited": "SDKs",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.2",
-    "settings.editor.selected.configurable": "File.Encoding",
-    "spring.configuration.checksum": "481bcfc7c4b842fec3da365c29371a17"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;SDKs&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;File.Encoding&quot;,
+    &quot;spring.configuration.checksum&quot;: &quot;481bcfc7c4b842fec3da365c29371a17&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveClassesOrPackagesDialog.RECENTS_KEY">
+      <recent name="com.github.fearthe13372.jrtb.command" />
       <recent name="com.github.fearthe13372.jrtb" />
     </key>
   </component>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,8 @@
+## 0.2.0-SNAPSHOT
+
+*   JRTB-3: implemented Command pattern for handling Telegram Bot commands
+
+## 0.1.0-SNAPSHOT
+
+*   JRTB-2: added stub telegram bot
+*   JRTB-0: added SpringBoot skeleton project

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.fearthe13372</groupId>
 	<artifactId>javarush-telegrambot</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>Javarush TelegramBot</name>
 	<description>Telegram bot for Javarush from community to community</description>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.7.RELEASE</version>
+		<version>2.7.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.github.fearthe13372</groupId>

--- a/src/main/java/com/github/fearthe13372/jrtb/bot/JavaRushTelegramBot.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/bot/JavaRushTelegramBot.java
@@ -1,4 +1,6 @@
 package com.github.fearthe13372.jrtb.bot;
+import com.github.fearthe13372.jrtb.command.CommandContainer;
+import com.github.fearthe13372.jrtb.service.SendBotMessageServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
@@ -6,30 +8,33 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+import java.util.Locale;
+
 /**
  * Telegrambot for Javarush Community from Javarush community.
  */
 @Component
 public class JavaRushTelegramBot extends TelegramLongPollingBot{
+    public static String Command_prefix = "/";
     @Value("${bot.username}")
     private String username;
     @Value("${bot.token}")
     private String token;
 
+    private final CommandContainer commandContainer;
+
+    public JavaRushTelegramBot (){
+        this.commandContainer = new CommandContainer(new SendBotMessageServiceImpl(this));
+    }
     @Override
     public void onUpdateReceived(Update update) {
         if(update.hasMessage() && update.getMessage().hasText()){
-            String message = update.getMessage().getText().trim();
-            String chatId = update.getMessage().getChatId().toString();
-            SendMessage sendMessage = new SendMessage();
-            sendMessage.setChatId(chatId);
-            sendMessage.setText(message);
-            try {
-                execute(sendMessage);
-            } catch (TelegramApiException e) {
-                e.printStackTrace();
-            }
-
+           String message = update.getMessage().getText().trim();
+           if(message.startsWith(Command_prefix))
+           {
+               String commandIdentifier = message.split(" ")[0].toLowerCase();
+               commandContainer.retrieveCommand(commandIdentifier).execute(update);
+           }
         }
     }
 

--- a/src/main/java/com/github/fearthe13372/jrtb/command/Command.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/Command.java
@@ -1,0 +1,5 @@
+package com.github.fearthe13372.jrtb.command;
+import org.telegram.telegrambots.meta.api.objects.Update;
+public interface Command {
+    void execute(Update update);
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/CommandContainer.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/CommandContainer.java
@@ -1,0 +1,25 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import com.google.common.collect.ImmutableMap;
+
+import static com.github.fearthe13372.jrtb.command.CommandName.*;
+
+public class CommandContainer {
+    private final ImmutableMap<String,Command> commandMap;
+    private final Command unknownCommand;
+
+    public CommandContainer(SendBotMessageService sendBotMessageService) {
+
+        commandMap = ImmutableMap.<String, Command>builder()
+                .put(START.getCommandName(), new StartCommand(sendBotMessageService))
+                .put(STOP.getCommandName(), new StopCommand(sendBotMessageService))
+                .put(HELP.getCommandName(), new HelpCommand(sendBotMessageService))
+                .put(NO.getCommandName(), new NoCommand(sendBotMessageService))
+                .build();
+        unknownCommand = new UnknownCommand(sendBotMessageService);
+    }
+    public Command retrieveCommand(String commandIndentifier){
+        return commandMap.getOrDefault(commandIndentifier,unknownCommand);
+    }
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/CommandName.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/CommandName.java
@@ -1,0 +1,17 @@
+package com.github.fearthe13372.jrtb.command;
+
+public enum CommandName {
+
+    START("/start"),
+    STOP("/stop"),
+    HELP("/help"),
+    NO("nocommand");
+    private final String commandName;
+    CommandName(String commandName){
+        this.commandName=commandName;
+    }
+
+    public String getCommandName() {
+        return commandName;
+    }
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/HelpCommand.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/HelpCommand.java
@@ -1,0 +1,24 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import static com.github.fearthe13372.jrtb.command.CommandName.*;
+
+public class HelpCommand implements Command{
+    private final SendBotMessageService sendBotMessageService;
+    //+static
+    public static final String HELP_MESSAGE = String.format("✨<b>Доступные команды</b>✨\n\n" +
+            "<b>Начать\\Закончить работу с ботом</b>\n" +
+            "%s - начать работу со мной\n" +
+            "%s - приостановить работу со мной\n\n" +
+            "%s - получить помощь в работе со мной\n", START.getCommandName(),STOP.getCommandName(),HELP.getCommandName());
+
+    public HelpCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+    sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),HELP_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/NoCommand.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/NoCommand.java
@@ -1,0 +1,19 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class NoCommand implements Command{
+    private final SendBotMessageService sendBotMessageService;
+    public static  final String NO_MESSAGE = "Я поддерживаю команды, начинающиеся со слеша(/).\n"
+            + "Чтобы посмотреть список команд введите /help";
+
+    public NoCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),NO_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/StartCommand.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/StartCommand.java
@@ -1,0 +1,17 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class StartCommand implements Command{
+    private final SendBotMessageService sendBotMessageService;
+    public final static String START_MESSAGE = "Привет. Я JavaRush Telegram Bot. Я помогу тебе посмотреть статьи тех авторов, которые тебе интересны! Я еще маленький и только учусь";
+
+    public StartCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+    @Override
+    public void execute(Update update){
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),START_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/StopCommand.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/StopCommand.java
@@ -1,0 +1,22 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class StopCommand implements Command {
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String STOP_MESSAGE = "Деактивировал все ваши подписки \uD83D\uDE1F.";
+
+    public StopCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), STOP_MESSAGE);
+    }
+
+
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/command/UnknownCommand.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/command/UnknownCommand.java
@@ -1,0 +1,19 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.net.CookieManager;
+
+public class UnknownCommand  implements Command {
+    public static final  String UNKNOWN_MESSAGE = "Не понимаю вас \uD83D\uDE1F, напишите /help чтобы увидеть список моих команд";
+    private final SendBotMessageService sendBotMessageService;
+
+    public UnknownCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+    @Override
+    public void execute(Update update) {
+    sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),UNKNOWN_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/service/SendBotMessageService.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/service/SendBotMessageService.java
@@ -1,0 +1,5 @@
+package com.github.fearthe13372.jrtb.service;
+
+public interface SendBotMessageService {
+    void sendMessage(String chatID, String message);
+}

--- a/src/main/java/com/github/fearthe13372/jrtb/service/SendBotMessageServiceImpl.java
+++ b/src/main/java/com/github/fearthe13372/jrtb/service/SendBotMessageServiceImpl.java
@@ -1,0 +1,29 @@
+package com.github.fearthe13372.jrtb.service;
+
+import com.github.fearthe13372.jrtb.bot.JavaRushTelegramBot;
+import org.jvnet.hk2.annotations.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+@Service
+public class SendBotMessageServiceImpl implements SendBotMessageService{
+    private  final JavaRushTelegramBot javaRushTelegramBot;
+
+    @Autowired
+    public SendBotMessageServiceImpl(JavaRushTelegramBot javaRushTelegramBot){
+        this.javaRushTelegramBot=javaRushTelegramBot;
+    }
+    @Override
+    public void sendMessage(String chatID, String message) {
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setChatId(chatID);
+        sendMessage.enableHtml(true);
+        sendMessage.setText(message);
+        try {
+            javaRushTelegramBot.execute(sendMessage);
+        }catch (TelegramApiException e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/SendBotMessageServiceTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/SendBotMessageServiceTest.java
@@ -1,0 +1,37 @@
+package com.github.fearthe13372.jrtb;
+import com.github.fearthe13372.jrtb.bot.JavaRushTelegramBot;
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import com.github.fearthe13372.jrtb.service.SendBotMessageServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+@DisplayName("Unit-level testing for SendBotMessageService")
+public class SendBotMessageServiceTest {
+    private SendBotMessageService sendBotMessageService;
+    private JavaRushTelegramBot javarushBot;
+    @BeforeEach
+    public void init(){
+        javarushBot = Mockito.mock(JavaRushTelegramBot.class);
+        sendBotMessageService = new SendBotMessageServiceImpl(javarushBot);
+    }
+    @Test
+    public void shouldProperlySendMessage()throws TelegramApiException{
+
+        String chatId = "test_chat_id";
+        String message = "test_message";
+
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setText(message);
+        sendMessage.setChatId(chatId);
+        sendMessage.enableHtml(true);
+
+        sendBotMessageService.sendMessage(chatId,message);
+
+        Mockito.verify(javarushBot).execute(sendMessage);
+
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/AbstractCommandTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/AbstractCommandTest.java
@@ -1,0 +1,40 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.bot.JavaRushTelegramBot;
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import com.github.fearthe13372.jrtb.service.SendBotMessageServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+abstract class AbstractCommandTest {
+    protected JavaRushTelegramBot javaRushTelegramBot = Mockito.mock(JavaRushTelegramBot.class);
+    protected SendBotMessageService sendBotMessageService = new SendBotMessageServiceImpl(javaRushTelegramBot);
+    abstract  String getCommandName();
+    abstract  String getCommandMessage();
+    abstract  Command getCommand();
+    
+    @Test
+    public void shouldProperlyExecuteCommand()throws TelegramApiException{
+        
+        Long chatId = 1234566352L;
+        Update update = new Update();
+        Message message = Mockito.mock(Message.class);
+        Mockito.when(message.getChatId()).thenReturn(chatId);
+        Mockito.when(message.getText()).thenReturn(getCommandMessage());
+        update.setMessage(message);
+
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setChatId(chatId.toString());
+        sendMessage.setText(getCommandMessage());
+        sendMessage.enableHtml(true);
+        //when
+        getCommand().execute(update);
+
+        //then
+        Mockito.verify(javaRushTelegramBot).execute(sendMessage);
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/CommandContainerTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/CommandContainerTest.java
@@ -1,0 +1,38 @@
+package com.github.fearthe13372.jrtb.command;
+
+import com.github.fearthe13372.jrtb.command.Command;
+import com.github.fearthe13372.jrtb.command.CommandContainer;
+import com.github.fearthe13372.jrtb.command.CommandName;
+import com.github.fearthe13372.jrtb.command.UnknownCommand;
+import com.github.fearthe13372.jrtb.service.SendBotMessageService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+@DisplayName("Unit-level testing for CommandContainer")
+public class CommandContainerTest {
+    private CommandContainer commandContainer;
+
+    @BeforeEach
+    public void init() {
+        SendBotMessageService sendBotMessageService = Mockito.mock(SendBotMessageService.class);
+        commandContainer = new CommandContainer(sendBotMessageService);
+    }
+    @Test
+    public void shouldGetAllTheExistingCommands() {
+        Arrays.stream(CommandName.values()).forEach(commandName -> {
+            Command command = commandContainer.retrieveCommand(commandName.getCommandName());
+            Assertions.assertNotEquals(UnknownCommand.class,command.getClass());
+        });
+    }
+    @Test
+    public void shouldReturnUnknownCommand(){
+        String unknownCommand = "/dssafasd";
+        Command command = commandContainer.retrieveCommand(unknownCommand);
+        Assertions.assertEquals(UnknownCommand.class,command.getClass());
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/HelpCommandTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/HelpCommandTest.java
@@ -1,0 +1,23 @@
+package com.github.fearthe13372.jrtb.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.fearthe13372.jrtb.command.CommandName.HELP;
+import static com.github.fearthe13372.jrtb.command.HelpCommand.HELP_MESSAGE;
+@DisplayName("Unit-level testing for HelpCommand")
+public class HelpCommandTest extends AbstractCommandTest{
+    @Override
+    String getCommandName() {
+        return HELP.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return HELP_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new HelpCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/NoCommandTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/NoCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.fearthe13372.jrtb.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.fearthe13372.jrtb.command.CommandName.NO;
+import static com.github.fearthe13372.jrtb.command.NoCommand.NO_MESSAGE;
+
+@DisplayName("Unit-level testing for NoCommand")
+public class NoCommandTest extends AbstractCommandTest {
+
+    @Override
+    String getCommandName() {
+        return NO.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return NO_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new NoCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/StartCommandTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/StartCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.fearthe13372.jrtb.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.fearthe13372.jrtb.command.CommandName.START;
+import static com.github.fearthe13372.jrtb.command.StartCommand.START_MESSAGE;
+
+@DisplayName("Unit-level testing for StartCommand")
+class StartCommandTest extends AbstractCommandTest {
+
+    @Override
+    String getCommandName() {
+        return START.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return START_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new StartCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/StopCommandTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/StopCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.fearthe13372.jrtb.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.fearthe13372.jrtb.command.CommandName.STOP;
+import static com.github.fearthe13372.jrtb.command.StopCommand.STOP_MESSAGE;
+
+@DisplayName("Unit-level testing for StopCommand")
+public class StopCommandTest extends AbstractCommandTest {
+
+    @Override
+    String getCommandName() {
+        return STOP.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return STOP_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new StopCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/fearthe13372/jrtb/command/UnknownCommandTest.java
+++ b/src/test/java/com/github/fearthe13372/jrtb/command/UnknownCommandTest.java
@@ -1,0 +1,24 @@
+package com.github.fearthe13372.jrtb.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.fearthe13372.jrtb.command.UnknownCommand.UNKNOWN_MESSAGE;
+
+@DisplayName("Unit-level testing for UnknownCommand")
+public class UnknownCommandTest extends AbstractCommandTest {
+
+    @Override
+    String getCommandName() {
+        return "/fdgdfgdfgdbd";
+    }
+
+    @Override
+    String getCommandMessage() {
+        return UNKNOWN_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new UnknownCommand(sendBotMessageService);
+    }
+}

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -1,3 +1,0 @@
-bot.username = testsjavarushcommunitybot
-bot.token = 6221884375:AAFXGm0_T3uhvO-o7eJ7hACn7yGElt8NInk
-


### PR DESCRIPTION
Implemented Command Pattern for handling Telegram bot commands.
Tests added, too.

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x]New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)